### PR TITLE
Add audio extraction tests

### DIFF
--- a/README.MD
+++ b/README.MD
@@ -72,3 +72,12 @@
 ## Contributing
 
 Feel free to open issues or pull requests for suggestions and improvements.
+
+## Running Tests
+
+Unit tests are written with [pytest](https://pytest.org). After installing the
+requirements, run the test suite from the repository root:
+
+```bash
+pytest
+```

--- a/tests/test_extract_audio.py
+++ b/tests/test_extract_audio.py
@@ -1,0 +1,51 @@
+import sys
+import types
+
+# Create dummy modules for optional dependencies so AudioTranscriber can be imported
+dummy = types.ModuleType("dummy")
+sys.modules.setdefault("whisper", dummy)
+openai_dummy = types.ModuleType("openai")
+openai_dummy.OpenAI = lambda *a, **k: None
+sys.modules.setdefault("openai", openai_dummy)
+torch_dummy = types.ModuleType("torch")
+torch_dummy.cuda = types.SimpleNamespace(is_available=lambda: False, init=lambda: None)
+sys.modules.setdefault("torch", torch_dummy)
+tk_dummy = types.ModuleType("tkinter")
+tk_dummy.filedialog = types.SimpleNamespace()
+tk_dummy.messagebox = types.SimpleNamespace()
+sys.modules.setdefault("tkinter", tk_dummy)
+sys.modules.setdefault("pypandoc", dummy)
+dummy.convert_file = lambda *a, **k: None
+ffmpeg_stub = types.ModuleType("ffmpeg")
+ffmpeg_stub.input = lambda *a, **k: None
+sys.modules.setdefault("ffmpeg", ffmpeg_stub)
+
+import importlib.util
+import os
+
+# Load AudioTranscriber module from file after stubbing dependencies
+spec = importlib.util.spec_from_file_location("AudioTranscriber", os.path.join(os.path.dirname(__file__), "..", "AudioTranscriber.py"))
+AudioTranscriber = importlib.util.module_from_spec(spec)
+spec.loader.exec_module(AudioTranscriber)
+
+
+def test_extract_audio_multiple_periods(monkeypatch):
+    # Set globals used by extract_audio
+    AudioTranscriber.pipelineFile = "example.v1.mp4"
+    AudioTranscriber.audio_folder = "/tmp"
+
+    # Mock ffmpeg chain to avoid actual processing
+    class DummyStream:
+        def output(self, *args, **kwargs):
+            return self
+        def run(self, overwrite_output=True):
+            pass
+    monkeypatch.setattr(AudioTranscriber.ffmpeg, 'input', lambda path: DummyStream())
+
+    # Mock filesystem interactions
+    monkeypatch.setattr(AudioTranscriber.os.path, 'exists', lambda path: True)
+    monkeypatch.setattr(AudioTranscriber.os, 'makedirs', lambda path: None)
+    monkeypatch.setattr(AudioTranscriber.os, 'replace', lambda src, dst: None)
+
+    result = AudioTranscriber.extract_audio("example.v1.mp4")
+    assert result == "example.v1.mp3"


### PR DESCRIPTION
## Summary
- fix `extract_audio` to handle filenames with multiple periods
- wrap script execution in a `__main__` guard so it can be imported
- add unit test for `extract_audio`
- document running the tests with pytest

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846ea742b9c832bac728873c55c1771