### PR TITLE
Fix typo in prompts and code

### DIFF
--- a/AudioTranscriber.py
+++ b/AudioTranscriber.py
@@ -71,7 +71,7 @@ def openai_summary(transcription_text):
         model = "gpt-4o",
         # messages = [
         #     {"role": "system", 
-        #      "content": "You are a professor and instructor who is knowledgable about the subject matter. You are creating detailed lesson notes based on a video transcript."},
+        #      "content": "You are a professor and instructor who is knowledgeable about the subject matter. You are creating detailed lesson notes based on a video transcript."},
         #     {"role": "user", 
         #     "content": "The following is a transcript of a lesson. Based on this video, create a detailed document that is so detailed that the reader will not need to watch the video anymore. Do not mention that the reader does not need to watch the video. Use markdown to format your notes. This is the transcript: " + transcription_text}
         # ]
@@ -83,7 +83,7 @@ def openai_summary(transcription_text):
     #     ]
         messages = [
             {"role": "system", 
-            "content": "You are a detailed mechanical engineering notetaker knowledgable about the subject matter. You are creating detailed meeting notes based on a meeting transcript."},
+            "content": "You are a detailed mechanical engineering notetaker knowledgeable about the subject matter. You are creating detailed meeting notes based on a meeting transcript."},
             {"role": "user",                                                                                      
              "content":
                 "Meeting Minutes: Develop comprehensive meeting minutes including: Attendees: List all participants. Discussion Points: Detail the topics discussed, including any debates, alternate viewpoints, problem statements, and current situations. Decisions Made: Record all decisions, including who made them and the rationale. Action Items: Specify tasks assigned, responsible individuals, and deadlines. Data & Insights: Display any data presented or insights shared that influenced the meeting\'s course, including any clarifications. Follow-Up: Note any agreed-upon follow-up meetings or checkpoints. Include all details in the notes, including all numbers and equations discussed. Do not summarize anything for the meeting notes. Write notes that are so detailed that the reader will not have to watch the video at all. Use markdown to format your notes. This is the transcript: " + transcription_text

--- a/Prompts/SkilledInstructor.txt
+++ b/Prompts/SkilledInstructor.txt
@@ -2,7 +2,7 @@
         model = "gpt-4o",
         messages = [
             {"role": "system", 
-             "content": "You are a professor and instructor who is knowledgable about the subject matter. You are creating detailed lesson notes based on a video transcript."},
+            "content": "You are a professor and instructor who is knowledgeable about the subject matter. You are creating detailed lesson notes based on a video transcript."},
             {"role": "user", 
             "content": "The following is a transcript of a lesson. Based on this video, create a detailed document that is so detailed that the reader will not need to watch the video anymore. Do not mention that the reader does not need to watch the video. Use markdown to format your notes. This is the transcript: " + transcription_text}
         ]


### PR DESCRIPTION
## Summary
- correct spelling of "knowledgeable" in audio transcript prompt
- correct same typo in SkilledInstructor prompt

## Testing
- `python -m py_compile AudioTranscriber.py`

------
https://chatgpt.com/codex/tasks/task_e_6846ea54bc54832baa816017a40c4921