### PR TITLE
Add WPF app and CLI updates

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+__pycache__/
+*.pyc
+VideoToDocXNotesWPF/bin/
+VideoToDocXNotesWPF/obj/

--- a/AudioTranscriber.py
+++ b/AudioTranscriber.py
@@ -26,6 +26,8 @@ def extract_audio(audio_file):
     work_folder = os.path.join(audio_folder, "PROCESSED VIDEOS")
     if not os.path.exists(work_folder):
         os.makedirs(work_folder)
+    # move the original video file that was processed
+    video_file = pipelineFile
     os.replace(video_file, os.path.join(work_folder, os.path.basename(video_file)))
 
     return mp3_audio_file_name
@@ -150,19 +152,23 @@ def MoveFilestoFolders(audio_folder, audio_file_path, transcription_path, md_pat
 
 #GET THE AUDIO FILE PATH
 if __name__ == "__main__":
-    root = filedialog.Tk()
-    root.wm_attributes('-topmost', 1)
-    root.withdraw()
+    import sys
+    if len(sys.argv) > 1:
+        filesList = [sys.argv[1]]
+    else:
+        root = filedialog.Tk()
+        root.wm_attributes('-topmost', 1)
+        root.withdraw()
 
-    files = filedialog.askopenfilenames(
-        parent=root,
-        filetypes=[("Video/Audio Files", "*.mp4 *.mkv *.mp3"), ("Transcript", "*.txt *.docx")],
-    )
-    filesList = list(files)
-    if not filesList:
-        messagebox.showerror(title="Error", message="No file selected.")
-        print("No file selected.")
-        exit()
+        files = filedialog.askopenfilenames(
+            parent=root,
+            filetypes=[("Video/Audio Files", "*.mp4 *.mkv *.mp3"), ("Transcript", "*.txt *.docx")],
+        )
+        filesList = list(files)
+        if not filesList:
+            messagebox.showerror(title="Error", message="No file selected.")
+            print("No file selected.")
+            exit()
 
     while filesList:
         pipelineFile = filesList.pop(0)

--- a/README.MD
+++ b/README.MD
@@ -80,3 +80,15 @@ requirements, run the test suite from the repository root:
 ```bash
 pytest
 ```
+
+## WPF Version
+
+A minimal Windows desktop interface is provided in the `VideoToDocXNotesWPF`
+folder. It allows you to select a file and runs `AudioTranscriber.py` in the
+background. To build it you will need the [.NET SDK](https://dotnet.microsoft.com/):
+
+```bash
+dotnet build VideoToDocXNotesWPF/VideoToDocXNotesWPF.csproj
+```
+
+Run the resulting executable on Windows to launch the GUI.

--- a/VideoToDocXNotesWPF/App.xaml
+++ b/VideoToDocXNotesWPF/App.xaml
@@ -1,0 +1,7 @@
+<Application x:Class="VideoToDocXNotesWPF.App"
+             xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+             xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+             StartupUri="MainWindow.xaml">
+    <Application.Resources>
+    </Application.Resources>
+</Application>

--- a/VideoToDocXNotesWPF/App.xaml.cs
+++ b/VideoToDocXNotesWPF/App.xaml.cs
@@ -1,0 +1,8 @@
+using System.Windows;
+
+namespace VideoToDocXNotesWPF
+{
+    public partial class App : Application
+    {
+    }
+}

--- a/VideoToDocXNotesWPF/MainWindow.xaml
+++ b/VideoToDocXNotesWPF/MainWindow.xaml
@@ -1,0 +1,8 @@
+<Window x:Class="VideoToDocXNotesWPF.MainWindow"
+        xmlns="http://schemas.microsoft.com/winfx/2006/xaml/presentation"
+        xmlns:x="http://schemas.microsoft.com/winfx/2006/xaml"
+        Title="VideoToDocXNotes" Height="200" Width="400">
+    <Grid Margin="10">
+        <Button Name="selectButton" Content="Select File" Width="100" Height="30" Click="OnSelectFile" HorizontalAlignment="Center" VerticalAlignment="Center"/>
+    </Grid>
+</Window>

--- a/VideoToDocXNotesWPF/MainWindow.xaml.cs
+++ b/VideoToDocXNotesWPF/MainWindow.xaml.cs
@@ -1,0 +1,56 @@
+using Microsoft.Win32;
+using System.Diagnostics;
+using System.IO;
+using System.Windows;
+
+namespace VideoToDocXNotesWPF
+{
+    public partial class MainWindow : Window
+    {
+        public MainWindow()
+        {
+            InitializeComponent();
+        }
+
+        private void OnSelectFile(object sender, RoutedEventArgs e)
+        {
+            var dlg = new OpenFileDialog
+            {
+                Filter = "Video/Audio Files|*.mp4;*.mkv;*.mp3|Transcript|*.txt;*.docx",
+                Multiselect = false
+            };
+
+            if (dlg.ShowDialog() == true)
+            {
+                RunPythonProcess(dlg.FileName);
+            }
+        }
+
+        private void RunPythonProcess(string filePath)
+        {
+            var startInfo = new ProcessStartInfo
+            {
+                FileName = "python",
+                Arguments = $"{Path.Combine(Directory.GetCurrentDirectory(), "AudioTranscriber.py")} \"{filePath}\"",
+                UseShellExecute = false,
+                RedirectStandardOutput = true,
+                RedirectStandardError = true
+            };
+
+            using var process = new Process { StartInfo = startInfo };
+            process.OutputDataReceived += (s, e) => { if (!string.IsNullOrEmpty(e.Data)) AppendOutput(e.Data); };
+            process.ErrorDataReceived += (s, e) => { if (!string.IsNullOrEmpty(e.Data)) AppendOutput(e.Data); };
+            process.Start();
+            process.BeginOutputReadLine();
+            process.BeginErrorReadLine();
+        }
+
+        private void AppendOutput(string text)
+        {
+            Dispatcher.Invoke(() =>
+            {
+                MessageBox.Show(text);
+            });
+        }
+    }
+}

--- a/VideoToDocXNotesWPF/VideoToDocXNotesWPF.csproj
+++ b/VideoToDocXNotesWPF/VideoToDocXNotesWPF.csproj
@@ -1,0 +1,8 @@
+<Project Sdk="Microsoft.NET.Sdk.WindowsDesktop">
+  <PropertyGroup>
+    <OutputType>WinExe</OutputType>
+    <TargetFramework>net6.0-windows</TargetFramework>
+    <UseWPF>true</UseWPF>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+</Project>


### PR DESCRIPTION
## Summary
- fix `extract_audio` bug and allow running `AudioTranscriber.py` with a file argument
- add a minimal WPF frontend to trigger the Python script
- update docs with instructions for the new app
- add `.gitignore` for build output

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6846f8d223c4832b956f5e999bf82d05